### PR TITLE
Add an epic poem struct and start the list of poems

### DIFF
--- a/epics.txt
+++ b/epics.txt
@@ -1,0 +1,342 @@
+==Ancient epics (to 500)==
+
+===20th to 10th century BC===
+
+*''[[Epic of Gilgamesh]]''  ([[Mesopotamian mythology]])
+*''[[Atra-Hasis|Atrahasis]]''  (Mesopotamian mythology)
+*''[[Enuma Elish]]'' ([[Babylonian mythology]])
+*''[[Legend of Keret]]'' ([[Ugarit|Ugaritic mythology]])
+*''Cycle of [[Kumarbi]]'' ([[Hurrian mythology]])
+
+===8th to 6th century BC===
+
+*''[[Iliad]]'', ascribed to [[Homer]]  ([[Greek mythology]])
+*''[[Odyssey]]'', ascribed to [[Homer]]  (Greek mythology)
+*''[[Works and Days]]'', ascribed to [[Hesiod]]  (Greek mythology)
+*''[[Theogony]]'', ascribed to [[Hesiod]]  (Greek mythology)
+*''[[Shield of Heracles]]'', ascribed to [[Hesiod]]  (Greek mythology)
+*''[[Catalogue of Women]]'', ascribed to [[Hesiod]]  (Greek mythology; only fragments survive)
+*''[[Cypria]]'', ''[[Aethiopis]]'', ''[[Little Iliad]]'', ''[[Iliupersis]]'', ''[[Nostoi]]'' and ''[[Telegony]]'', forming the so-called [[Epic Cycle]] (only fragments survive)
+*''[[Oedipodea]]'', ''[[Thebaid (Greek poem)|Thebaid]]'', ''[[Epigoni (epic)|Epigoni]]'' and ''[[Alcmeonis]]'', forming the so-called [[Theban Cycle]] (only fragments survive)
+*A series of poem ascribed to Hesiod during antiquity (of which only fragments survive): ''[[Aegimius (poem)|Aegimius]]'' (alternatively ascribed to Cercops of Miletus), ''[[Astronomia]]'', ''[[Descent of Perithous]]'', ''[[Idaean Dactyls (poem)|Idaean Dactyls]]'' (almost completely lost), ''[[Megala Erga]]'', ''[[Megalai Ehoiai]]'', ''[[Melampodia]]'' and ''[[Wedding of Ceyx]]''
+*''[[Capture of Oechalia]]'', ascribed to Homer or [[Creophylus of Samos]] during antiquity (only fragment survives)
+*''[[Phocais]]'', ascribed to Homer during antiquity (only fragment survives)
+*''[[Titanomachy (epic poem)|Titanomachy]]'' ascribed to [[Eumelus of Corinth]] (only fragment survives)
+*''[[Danais (epic)|Danais]]'' (written by one of the [[cyclic poets]] and from which the Danaid tetralogy of Aeschylus draws its material), ''[[Minyas (poem)|Minyas]]'' and ''[[Naupactia]]'', almost completely lost
+
+===8th century BC to 3rd century AD===
+
+*''[[Mahābhārata]]'', ascribed to [[Veda Vyasa]]  ([[Hindu mythology|Indian mythology]])
+*''[[Ramayana]]'', ascribed to [[Valmiki]]  ([[Hindu mythology|Indian mythology]])
+
+===3rd century BC===
+
+*''[[Argonautica]]'' by [[Apollonius of Rhodes]] (Greek mythology)
+
+===2nd century BC===
+
+*''[[Annales (Ennius)|Annales]]'' by [[Ennius]] (Roman history; only fragments survive)
+
+===1st century BC===
+
+*''[[De rerum natura]]'' by [[Lucretius]] (natural philosophy) 
+*''[[Georgics]]'' by [[Virgil]]
+*''[[Aeneid]]'' by [[Virgil]]  ([[Roman mythology]])
+
+===1st century AD===
+
+*''[[Metamorphoses (poem)|Metamorphoses]]'' by [[Ovid]]  (Greek and Roman mythology)
+*''[[Pharsalia]]'' by [[Marcus Annaeus Lucanus|Lucan]]  ([[Battle of Pharsalus|Roman history]])
+*''Argonautica'' by [[Gaius Valerius Flaccus]] (Roman poet, Greek mythology; incomplete)
+*''[[Punica (poem)|Punica]]'' by [[Silius Italicus]]  ([[Second Punic War|Roman history]])
+*''[[Thebaid (Latin poem)|Thebaid]]'' and ''[[Achilleid]]'' by [[Statius]]  (Roman poet, Greek mythology; latter poem incomplete)
+
+===2nd century===
+
+*''[[Buddhacarita]]'' by [[Asvaghosa|Aśvaghoṣa]]  ([[Indian epic poetry]])
+
+===2nd to 5th century===
+
+*[[The Five Great Epics of Tamil Literature]]: ''[[Silappatikaram|Cilappatikāram]]'', ''[[Manimekalai]]'', ''[[Cīvaka Cintāmaṇi]]'', ''[[Valayapathi]]'', ''[[Kundalakesi|Kundalakēci]]''
+
+===3rd to 4th century===
+
+*''[[Posthomerica]]'' by [[Quintus of Smyrna]] (Greek mythology)
+*''De raptu Proserpinae'' by [[Claudian]] (Roman poet, Greek mythology; incomplete)
+
+===4th century===
+
+*''[[Kumaarasambhavam|Kumārasambhava]]'' by [[Kālidāsa]]  ([[Indian epic poetry]])
+*''[[Raghuvaṃśa]]'' by Kālidāsa (Indian epic poetry)
+
+===5th century===
+
+*''[[Argonautica Orphica]]'' by Anonymous (Greek mythology)
+*''[[Dionysiaca]]'' by [[Nonnus]] (Greek mythology)
+*''[[Mahavamsa]]'', written in Pali
+*''[[Yadegar-e Zariran]]'', written in Middle Persian
+
+===Medieval epics (500–1500)===
+[[File:Statue of Ferdowsi in Rome.JPG|thumb|Statue of Iranian poet [[Ferdowsi]] in Rome, Italy. Ferdowsi's national epic [[Shahnameh]] played an important role in revival of Iranian [[patriotism]] and the [[Persian language]] after both were systematically suppressed by the Arab occupation of Iran]]
+
+====7th century====
+*''[[Táin Bó Cúailnge]]'' ([[Old Irish]])
+*''[[Bhaṭṭikāvya]]'',<ref>Fallon, Oliver. Bhatti's Poem: The Death of Rávana (Bhaṭṭikāvya). New York 2009: [[Clay Sanskrit Library]], [http://www.claysanskritlibrary.org/]. {{ISBN|978-0-8147-2778-2}}, {{ISBN|0-8147-2778-6}}.</ref> Sanskrit courtly epic based on the [[Rāmāyaṇa]] and the [[Aṣṭādhyāyī]] of [[Pāṇini]]
+*''[[Kiratarjuniya]]'' by [[Bharavi]], Sanskrit epic based on an episode in the [[Mahabharata]]
+*''[[Shishupala Vadha]]'' by [[Magha (poet)|Magha]], Sanskrit epic based on another episode in the [[Mahabharata]]
+
+====8th to 10th century====
+*''[[Beowulf]]'' ([[Old English]])
+*''[[Waldere]]'', Old English version of the story told in ''Waltharius'' (below), known only as a brief fragment
+*''[[Daredevils of Sassoun]]'' ([[Armenian language|Armenian]])
+*''[[Bhagavata Purana]]'' ([[Sanskrit language|Sanskrit]]) "''Stories of the Lord''", based on earlier sources
+*''[[Lay of Hildebrand]]'' and ''[[Muspilli]]'' ([[Old High German]], c.870)
+*''[[Kakawin Ramayana]]'', Javanese version of the Ramayana (c. 870)
+*''[[Shahnameh]]'' ([[Persian literature]]; details [[History of Iran|Persian]] legend and history from prehistoric times to the fall of the [[Sassanid Empire]], by [[Ferdowsi]])
+*''[[Waltharius]]'' by Ekkehard of St. Gall ([[Latin]]); about [[Walter of Aquitaine]]
+*''[[Poetic Edda]]'' (no particular authorship; oral tradition of the [[Germanic peoples|North Germanic peoples]])
+*''[[Vikramarjuna Vijaya]]'' and ''[[Ādi purāṇa]]'' (c. 941), [[Kannada]] poems by [[Adikavi Pampa]]
+*''[[Ajitha Purana]]'' and ''Gadaayuddha'' (c.993 and c.999), Kannada poems by [[Ranna]]
+*''[[Neelakesi]]'' ([[Tamil language|Tamil]] Jain epic)
+
+====11th century====
+[[File:ვეფხისტყაოსანი XVII საუკუნე.jpg|thumb|[[The Knight in the Panther's Skin]] by [[Shota Rustaveli]], one of the greatest Georgian poets.]]
+*''[[Taghribat Bani Hilal]]'' ([[Arabic language|Arabic]]); see also [[Arabic epic literature]]
+*''[[Ruodlieb]]'' ([[Latin]]), by a German author
+*''[[Digenis Acritas|Digenis Akritas]]'' ([[Greek language|Greek]]); about a hero of the [[Byzantine Empire]]
+*''[[Epic of King Gesar]]'' ([[Classical Tibetan|Tibetan]])
+*''[[Carmen Campidoctoris]]'', the first poem about [[El Cid Campeador]] (c. 1083)
+*''[[Borzu Nama]]'', ascribed to 'Amid Abu'l 'Ala' 'Ata b. Yaqub Kateb Razi (Persian epic with a main character and a poetic style related to the "Shahnameh")
+*''[[Faramarz Nama]]'' (Persian epic with a main character and a poetic style related to the "Shahnameh")
+
+====12th century====
+*''[[Acallam na Senórach]]'' ([[Middle Irish]])
+*''[[The Song of Roland]]'' ([[Old French]])
+*''[[The Knight in the Panther's Skin]]'' ([[Georgian language|Georgian]]) by [[Shota Rustaveli]]
+*''[[Alexandreis]]'' by [[Walter of Châtillon]] ([[Latin]])
+*''[[De bello Troiano]]'' and the lost ''[[Antiocheis (Joseph of Exeter)|Antiocheis]]'' by [[Joseph of Exeter]]
+*''[[Carmen de Prodicione Guenonis]]'', version of the story of the ''Song of Roland'' in [[Latin]]
+*''[[Architrenius]]'' by [[John of Hauville]], [[Latin]] satire
+*''[[Liber ad honorem Augusti]]'' by [[Peter of Eboli]], narrative of the conquest of [[Sicily]] by [[Henry VI, Holy Roman Emperor]] ([[Latin]])
+*''[[The Tale of Igor's Campaign]]'' and ''[[Bylinas]]'' (11th-19th centuries)
+*''[[Naishadha Charita]]'' by [[Sriharsha]]
+*''[[Roman de Troie]]'' by [[Benoît de Sainte-Maure]], medieval re-telling of the Trojan War
+*''[[Poem of Almeria]]'' (Latin)
+*''[[Roman de Brut]]'' and ''[[Roman de Rou]]'' by [[Wace]], chronicles in [[Norman language]]
+*''[[Eupolemius]]'' by an anonymous German-speaking author
+*''[[Bahman Nama]]'' and ''[[Kush Nama]]'', ascribed to Hakim Īrānšāh b. Abi'l Khayr
+*''[[Banu Goshasp|Banu Goshasp Nama]]''
+*''[[Ramavataram]]'' by [[Kambar (poet)|Kambar]], based on the "Ramayana"
+
+====13th century====
+*''[[Nibelungenlied]]'' ([[Middle High German]])
+*''[[Kudrun]]'' (Middle High German)
+*''[[Brut (Layamon)|Brut]]'' by [[Layamon]] (Early [[Middle English]])
+*''[[Chanson de la Croisade Albigeoise]]'' ("Song of the Albigensian Crusade"; [[Occitan language|Occitan]])
+*''[[Antarah ibn Shaddad|Antar]]'' ([[Arabic language|Arabic]]); see also [[Arabic epic literature]]
+*''[[Sirat al-Zahir Baibars]]'' ([[Arabic language|Arabic]]); see also [[Arabic epic literature]]
+*''[[Osman's Dream]]'' ([[Ottoman Turkish language|Ottoman Turkish]])
+*''[[Epic of Sundiata]]''
+*''[[Cantar de Mio Cid|El Cantar de Mio Cid]]'', Spanish epic of the [[Reconquista]] ([[Old Spanish]])
+*''[[De triumphis ecclesiae]]'' by [[Johannes de Garlandia (philologist)|Johannes de Garlandia]] ([[Latin]])
+*''[[Gesta Regum Britanniae]]'' by [[William of Rennes]] ([[Latin]])
+*''[[Van den vos Reynaerde]]'' ([[Middle Dutch]])
+*''[[Poema de Fernán González]]'', [[cantar de gesta]] by a monk of San Pedro de Arlanza; 1250–1266 ([[Old Spanish language|Old Spanish]])
+*''[[Jewang ungi]]'' by Yi Seung-hyu ("Rhymed Chronicles of Sovereigns"; 1287 [[Korea]])
+*''[[Basava purana]]'' by [[Palkuriki Somanatha]] ([[Telugu language|Telugu]])
+
+====14th century====
+*''[[Divine Comedy]]'' by [[Dante Alighieri]]
+*''[[Cursor Mundi]]'' by an anonymous cleric (c. 1300)
+*''[[Africa (Petrarch)|Africa]]'' by [[Petrarch]] ([[Latin]])
+*''[[The Tale of the Heike]]'', [[Japanese people|Japanese]] epic war tale
+*''[[The Brus]]'' by [[John Barbour (poet)|John Barbour]] ([[Scots language|Scots]])
+*''[[La Spagna]]'', attributed to Sostegno di Zanobi (c. 1350-1360)
+*''[[Mocedades de Rodrigo]]'' (c. 1360)
+*''[[Siege of Jerusalem (poem)|Siege of Jerusalem]]'' (c. 1370-1380, [[Middle English]])
+*''[[Zafarnamah (Mustawfi)|Zafarnamah]]'' by [[Hamdollah Mostowfi]]
+
+====15th century====
+*''[[Yuan Phai]]'' ({{lang-th|ลิลิตยวนพ่าย}}) by Royal Poets of King [[Borommatrailokkanat|Borommatrai-lokkanat]] (c. 1475)
+*''[[Mahachat Kham luang]]'' ({{lang-th|มหาชาติคำหลวง}}) a Siamese retelling of [[Vessantara Jataka]] by Royal Poets of King [[Borommatrailokkanat|Borommatrai-lokkanat]] (1492) 
+*''[[Orlando innamorato]]'' by [[Matteo Maria Boiardo]] (1495)
+*''[[Shmuel-Bukh]]'' ([[Yiddish|Old Yiddish]] chivalry romance based on the Biblical [[book of Samuel]])
+*''[[Mlokhim-Bukh]]'' ([[Yiddish|Old Yiddish]] epic poem based on the Biblical [[Books of Kings]])
+*''[[Book of Dede Korkut]]''
+*''[[Morgante]]'' by [[Luigi Pulci]] (1485), with elements typical of the mock-heroic genre
+*''[[The Actes and Deidis of the Illustre and Vallyeant Campioun Schir William Wallace|The Wallace]]'' by [[Blind Harry]] ([[Scots language|Scots]] chivalric poem)
+*''[[Troy Book]]'' by [[John Lydgate]], about the Trojan war (Middle English)
+*''[[Heldenbuch]]'', a group of manuscripts and prints of the 15th and 16th centuries, typically including material from the [[Theodoric cycle]] and the cycle of Hugdietrich, [[Wolfdietrich]] and [[Ortnit]]
+*''[[Ibong Adarna]]'', whose real author is not known
+
+===Modern epics (from 1500)===
+
+====16th century====
+*''[[Phra Lo|Lilit Phra Lo]]'' ({{lang-th|ลิลิตพระลอ}}) by King [[Ramathibodi II]] (c. 1491-1529)
+*''[[Judita]]'' by [[Marko Marulić]] (1501)
+*''[[Orlando Furioso]]'' by [[Ludovico Ariosto]] (1516)
+*''[[Davidiad]]'' by [[Marko Marulić]] (1517)
+*''[[Christiad]]'' by [[Marco Girolamo Vida]] (1535)
+*''[[Os Lusíadas]]'' by [[Luís de Camões]] (c.1572)<ref name="WDL">{{cite web |url = http://www.wdl.org/en/item/11198/ |title = The Lusiads |website = [[World Digital Library]] |date = 1800–1882 |accessdate = 2013-08-31 }}</ref>
+*''[[L'Amadigi]]'' by [[Bernardo Tasso]] (1560)
+*''[[La Araucana]]'' by [[Alonso de Ercilla y Zúñiga]] (1569–1589)
+*''[[La Gerusalemme liberata]]'' by [[Torquato Tasso]] (1575)
+*''[[Ramacharitamanasa]]'' (based on the ''[[Ramayana]]'') by Goswami [[Tulsidas]] (1577)
+*''[[Journey to the West]]'', by [[Wu Cheng'en]] (c. 1592), prose epic
+*''[[The Faerie Queene]]'' by [[Edmund Spenser]] (1596)
+*''[[Venus and Adonis (Shakespeare poem)|Venus and Adonis]]'' (1593), and ''[[The Rape of Lucrece|Lucrece]]'' (1594) by [[Shakespeare]]
+
+====17th century====
+*''[[La Argentina (poem)|La Argentina]]'' by [[Martín del Barco Centenera]] (1602)
+*''[[La Cleopatra (poem)|La Cleopatra]]'' by [[Girolamo Graziani]] (1632)
+*''[[Biag ni Lam-ang]]'' by Pedro Bucaneg (1640)
+*''[[Il Conquisto di Granata]]'' by [[Girolamo Graziani]] (1650)
+*''[[The Tenth Muse Lately Sprung Up in America|Exact Epitome of the Four Monarchies]]'' by [[Anne Bradstreet]] (1650)<ref>{{cite book|last=Pender|first=Patricia|title=Early Modern Women's Writing and the Rhetoric of Modesty|url=https://books.google.com/books?id=IK-pX35PvCkC&pg=PA166|year=2012|publisher=Palgrave Macmillan|isbn=9781137008015|page=166}}</ref>
+*''[[Peril of Sziget|Szigeti veszedelem]]'', also known under the Latin title '' Obsidionis Szigetianae'', a [[Hungarian language|Hungarian]] epic by [[Nikola Zrinski|Miklós Zrínyi]] (1651)
+*''[[Gondibert]]'' by [[William Davenant]] (1651)
+*''[[Paradise Lost]]'' (1667) and ''[[Paradise Regained]]'' (1671) by [[John Milton]]
+*''[[Khun Chang Khun Phaen]]'' ({{lang-th|ขุนช้างขุนแผน}}) a Thai epic poem by anonymous folk poets (c. 1650-1700)<ref>{{cite journal|last1=Baker|first1=Chris|last2=Phongpaichit|first2=Pasuk|title=The Career of Khun Chang Khun Phaen|journal=''Journal of Siam Society''|volume=97|year=2009|pages=1-42|url=http://www.siam-society.org/pub_JSS/jss097BakerPasuk.pdf}}</ref>
+
+====18th century====
+*''[[Kumulipo]]'' by [[Keaulumoku]] (1700) an [[Ancient Hawaii]]an cosmogonic genealogy first published in 1889
+*''[[Henriade]]'' by [[Voltaire]] (1723)
+*''[[Utendi wa Tambuka]]'' by Bwana Mwengo (1728)
+*''[[La Pucelle d'Orléans]]'' by [[Voltaire]] (1756)
+*''[[The Seasons (poem)|The Seasons]]'' by Kristijonas Donelaitis (1765-1775)
+*''[[O Uraguai]]'' by Basílio da Gama (1769)
+*''[[Caoineadh Airt Uí Laoghaire]]'' by [[Eibhlín Dubh Ní Chonaill]] (1773)
+*''[[Caramuru (epic poem)|Caramuru]]'' by [[Santa Rita Durão]] (1781)
+*''[[Joan of Arc (poem)|Joan of Arc]]'' by [[Robert Southey]] (1796)
+*''[[Hermann and Dorothea]]'' by [[Johann Wolfgang von Goethe]] (1797)
+
+====19th century====
+*''[[The Tale of Kieu|The Tale of Kiều]]'' by [[Nguyễn Du]] (c. 1800)
+*''[[Thalaba the Destroyer]]'' by [[Robert Southey]] (1801)
+*''[[Madoc (poem)|Madoc]]'' by [[Robert Southey]] (1805)
+*''[[The Columbiad]]'' by [[Joel Barlow]] (1807)
+*''[[Milton: A Poem in Two Books|Milton: A Poem]]'' by [[William Blake]] (1804–1810)
+*''[[Marmion (poem)|Marmion]]'' by [[Walter Scott]] (1808)
+*''[[Childe Harold's Pilgrimage]]'' by [[Lord Byron]], narrating the travels of Childe Harold (1812-1818)<ref name="Stephen Greenblatt 2012">Stephen Greenblatt et al. The Norton Anthology of English Literature, volume D, 9th edition (Norton, 2012)</ref>
+*''[[Queen Mab (poem)|Queen Mab]]'' by [[Percy Bysshe Shelley]] (1813)
+*''[[Roderick the Last of the Goths]]'' by [[Robert Southey]] (1814)
+*''[[The Lord of the Isles]]'' by [[Walter Scott]] (1813)
+*''[[Alastor, or The Spirit of Solitude]]'' by [[Percy Bysshe Shelley]] (1815)
+*''[[The Revolt of Islam]] (Laon and Cyntha)'' by [[Percy Bysshe Shelley]] (1817)
+*''[[Harold the Dauntless]]'' by [[Walter Scott]] (1817)
+*''[[Endymion (poem)|Endymion]]'', (1818) by [[John Keats]]
+*''[[Hyperion (poem)|Hyperion]]'' (1818) and ''[[The Fall of Hyperion: A Dream|The Fall of Hyperion]]'' (1819) by [[John Keats]]
+*''[[The Battle of Marathon: A Poem|The Battle of Marathon]]'' by [[Elizabeth Barrett Browning]] (1820)
+*''[[Phra Aphai Mani]]'' by [[Sunthorn Phu]] (1821 or 1822–1844)
+*''[[Don Juan (Byron)|Don Juan]]'' by [[Lord Byron]] (1824), an example of a "mock" epic in that it parodies the epic style of the author's predecessors<ref name="Stephen Greenblatt 2012"/>
+*''Camões'' by [[Almeida Garrett]] (1825), narrating the last years and deeds of [[Luís de Camões]] <ref>{{Cite journal|date=2017-06-24|title=Almeida Garrett|url=https://en.wikipedia.org/w/index.php?title=Almeida_Garrett&oldid=787242590|journal=Wikipedia|language=en}}</ref>
+*''Dona Branca'' by [[Almeida Garrett]] (1826), the fantastic tale of the forbidden love between [[Portuguese people|Portuguese]] princesse Branca and [[Moors|Moorish]] king Aben-Afan <ref>{{Cite journal|date=2017-06-24|title=Almeida Garrett|url=https://en.wikipedia.org/w/index.php?title=Almeida_Garrett&oldid=787242590|journal=Wikipedia|language=en}}</ref>
+*''[[Tamerlane (poem)|Tamerlane]]'' by [[Edgar Allan Poe]] (1827)
+*''[[Creation, Man and the Messiah]]'' by [[Henrik Wergeland]] (1829)
+*''[[Prometheus Bound]]'' by [[Aeschylus]], translated by [[Elizabeth Barrett Browning]] (1833)
+*''[[Pan Tadeusz]]'' by [[Adam Mickiewicz]] (1834)
+*''[[The Baptism on the Savica]]'' (''Krst pri Savici'') by [[France Prešeren]] (1836)
+*''[[Florante at Laura]]'', an ''[[awit (poem)|awit]]'' by [[Francisco Balagtas]] (1838)
+*''[[King Alfred (poem)|King Alfred]]'' by [[John Fitchett (poet)|John Fitchett]] (completed by Robert Roscoe and published in 1841-1842)
+*''[[János Vitéz]]'' by [[Sándor Petőfi]] (1845)
+*''[[Smrt Smail-age Čengića]]'' by [[Ivan Mažuranić]] (1846)
+*''Toldi'' (1846), ''Toldi szerelme'' (''"Toldi's Love"'', 1879) and ''Toldi estéje'' (''"Toldi's Night"'', 1848) by [[János Arany]], forming the so-called "[[Toldi trilogy]]"
+*''[[Evangeline]]'' by [[Henry Wadsworth Longfellow]] (1847)
+*''[[The Mountain Wreath]]'' by [[Petar II Petrović-Njegoš]] (1847)
+*''[[The Tales of Ensign Stål]]'' by [[Johan Ludvig Runeberg]] (first part published in 1848, second part published in 1860)
+*''[[Kalevala]]'' by [[Elias Lönnrot]] (1849 [[Finnish mythology]])
+*''[[I-Juca-Pirama]]'' by [[Gonçalves Dias]] (1851)
+*''[[Kalevipoeg]]'' by [[Friedrich Reinhold Kreutzwald]] (1853 [[Estonian mythology]])
+*''[[The Prelude]]'' by [[William Wordsworth]]
+*''[[Song of Myself]]'' by [[Walt Whitman]] (1855)
+*''[[The Song of Hiawatha]]'' by [[Henry Wadsworth Longfellow]] (1855)
+*''[[The Saga of King Olaf]]'' by [[Henry Wadsworth Longfellow]] (1856-1863)
+*''[[Aurora Leigh]]'' by [[Elizabeth Barrett Browning]] (1857)
+*''[[Meghnad Badh Kavya]]'' by [[Michael Madhusudan Dutta]] (1861)
+*''[[Terje Vigen]]'' by [[Henrik Ibsen]] (1862)
+*''[[La Légende des siècles|La Légende des Siècles]]'' (''The Legend of the Centuries'') by [[Victor Hugo]] (1859–1877)
+*''[[The Earthly Paradise]]'' by [[William Morris]] (1868-1870)
+*''[[Ibonia]]'', oral epic of Madagascar (first transcription: 1870)
+*''[[Martín Fierro]]'' by [[José Hernández (writer)|José Hernández]] (1872)
+*''[[Idylls of the King]]'' by [[Alfred Lord Tennyson]] (c. 1874)
+*''[[Clarel]]'' by [[Herman Melville]] (1876)
+*''[[The Story of Sigurd the Volsung and the Fall of the Niblungs]]'' by [[William Morris]] (1876)
+*''[[L'Atlàntida]]'' by [[Jacint Verdaguer]] (1877)
+*''[[The Light of Asia]]'' by [[Edwin Arnold]] (1879)
+*''[[The City of Dreadful Night]]'' by [[James Thomson (B.V.)]] (finished in 1874, published in 1880)
+*''[[Tristram of Lyonesse]]'' by [[Algernon Charles Swinburne]] (1882)
+*''[[Eros and Psyche]]'' by [[Robert Bridges]] (1885)
+*''[[La Fin de Satan]]'' by [[Victor Hugo]] (written between 1855 and 1860, published in 1886)
+*''[[Canigó#Literature|Canigó]]'' by [[Jacint Verdaguer]] (1886)
+*''[[Lāčplēsis]]'' ('The Bear-Slayer') by [[Andrejs Pumpurs]] (1888; Latvian Mythology)
+*''[[Tabaré (poem)|Tabaré]]'' by [[Juan Zorrilla de San Martín]] (1888; national epic of Uruguay)
+*''[[The Wanderings of Oisin]]'' by [[William Butler Yeats]] (1889)
+*''[[Kotan Utunnai]]'', Ainu epic, recorded in the 1880s, published in 1890
+*''[[Lục Vân Tiên]]'' by [[Nguyễn Đình Chiểu]]
+*''[[Amir Arsalan]]'', narrated by Mohammad Ali Naqib al-Mamalek to the Qajar Shah of Persia
+
+====20th century====
+*''[[The Divine Enchantment]]'' by [[John Neihardt]] (1900)
+*''[[Lahuta e Malcís]]'' by [[Gjergj Fishta]] (composed 1902-1937)
+*''[[Ural-batyr]]'' ([[Bashkirs]] oral tradition set in the written form by Mukhamedsha Burangulov in 1910)
+*''[[The Ballad of the White Horse]]'' by [[G. K. Chesterton]] (1911)
+*''[[Fernando Pessoa#Mensagem|Mensagem]]'' by [[Fernando Pessoa]] (composed 1913-1934)
+*''[[The Cantos]]'' by [[Ezra Pound]] (composed 1915-1969)
+*''[[Dorvyzhy]]'', Udmurt national epic compiled in Russian by Mikhail Khudiakov (1920) basing on folklore works
+*''[[The Legend of Sigurd and Gudrún]]'' by [[J. R. R. Tolkien]] (composed 1920-1939, published 2009)
+*''[[Cycle of the West|A Cycle of the West]]'' by [[John Neihardt]] (composed 1921-1949)
+*''[[The Odyssey: A Modern Sequel]]'' by [[Nikos Kazantzakis]] (Greek verse, composed 1924-1938)
+*''[[Dymer]]'' by [[C. S. Lewis]] (1926)
+*''[[Louis Zukofsky#.22A.22|"A"]]'' by [[Louis Zukofsky]] (composed 1927-1978)
+*''[[John Brown's Body (poem)|John Brown's Body]]'' by [[Stephen Vincent Benét]] (1928)
+*''[[The Fall of Arthur]]'' by [[J. R. R. Tolkien]] (composed c.1930-1934, published 2013)
+*''[[The Bridge (long poem)|The Bridge]]'' by [[Hart Crane]] (1930)
+*''[[Kamayani]]'' by [[Jaishankar Prasad]] (1936)
+*''[[Canto General]]'' by [[Pablo Neruda]] (1938-1950)
+*''[[Paterson (poem)|Paterson]]'' by [[William Carlos Williams]] (composed c.1940-1961)
+*''[[Sugata Saurabha (epic)|Sugata Saurabha]]'' by [[Chittadhar Hridaya]] (1941-1945)
+*''[[Victory for the Slain]]'' by [[Hugh John Lofting]] (1942)
+*''[[Rashmirathi]]'' (1952), ''[[Hunkar (epic poem)|Hunkar]]'' by [[Ramdhari Singh 'Dinkar']]
+*''[[Savitri: A Legend and a Symbol|Savitri]]'' by [[Aurobindo Ghose]] (1950)
+*''[[Charles Olson#The Maximus Poems|The Maximus Poems]]'' by [[Charles Olson]] (composed 1950-1970)
+*''[[Aniara]]'' by [[Harry Martinson]] (composed 1956)
+*''[[Song of Lawino]]'' by [[Okot p'Bitek]] (1966)
+*''[[The Banner of Joan]]'' by [[H. Warner Munn]] (1975)
+*''[[Kristubhagavatam]]'' by [[P. C. Devassia]] (1976)
+*''[[The Changing Light at Sandover]]'' by [[James Merrill]] (composed 1976-1982)
+*''[[The Battlefield Where The Moon Says I Love You]]'' by [[Frank Stanford]] (published 1977)
+*''[[Emperor Shaka the Great]]'' by [[Mazisi Kunene]] (1979)
+*''[[The Lay of the Children of Húrin]]'' and ''[[The Lay of Leithian]]'' by [[J. R. R. Tolkien]] (published 1985)
+*''Giannina [[Braschi's Empire of Dreams]] (1988)
+*''[[Omeros]]'' by [[Derek Walcott]] (1990)
+*''[[Arundhati (epic)|Arundhati]]'' by [[Jagadguru Rambhadracharya]] (1994)
+*''[[Mastorava]]'' by A. M. Sharonov (1994)
+*''[[Astronautilia|Astronautilía Hvězdoplavba]]'' by [[Jan Křesadlo]] (1995)
+*''[[Fredy Neptune|Fredy Neptune: A Novel in Verse]]'' by [[Les Murray (poet)|Les Murray]] (1998)
+
+====21st century====
+*''[[Sribhargavaraghaviyam]]'' (2002), ''[[Ashtavakra (epic)|Ashtavakra]]'' (2009) and ''[[Gitaramayanam]]'' (2009-2010, published in 2011) by [[Jagadguru Rambhadracharya]]
+
+
+
+== Other epics ==
+<!-- PLEASE RESPECT ALPHABETICAL ORDER -->
+*''[[Gesta Berengarii imperatoris]]''
+*''[[Epic of Bamana Segu]]'', oral epic of the [[Bambara people]], composed in the 19th century and recorded in the 20th century
+*''[[Epic of Darkness]]'', tales and legends of primeval China
+*''[[Epic of Jangar]]'', poem of the [[Oirat people]]
+*''[[Epic of Köroğlu]]'', [[Turkic people|Turkic]] oral tradition written down mostly in 18th century
+*''[[Epic of the Forgotten]]'', Bulgarian poetic saga
+*''[[Hikayat Seri Rama]]'', Malay versione of the Ramayana
+*''[[Hinilawod]]'', Filipino epic from the island of [[Panay]]
+*''[[Khun Chang Khun Phaen]]'', a Thai poem
+*''[[Klei Khan Y Dam San]]'', a Vietnamese poem
+*''[[Koti and Chennayya]]'' and ''[[Epic of Siri]]'', Tulu poems
+*''[[Kutune Shirka]]'', sacred [[yukar]] epic of the [[Ainu people]] of which several translations exist
+*''[[Parsifal]]'' by [[Richard Wagner]] (opera, composed 1880-1882)
+*''[[Pasyon|Pasyón]]'', Filipino religious epic, of which the 1703 and 1814 versions are popular
+*''[[Ramakien]]'', Thailand's national epic derived from the [[Ramayana]]
+*''[[Der Ring des Nibelungen]]'' by [[Richard Wagner]] (opera, composed 1848-1874)
+*''[[Siribhoovalaya]]'', a unique work of multi-lingual [[Kannada literature|literature]] written by [[Kumudendu Muni]], a [[Jainism|Jain]] monk
+*''[[Epic of Sundiata|Sundiata]], an epic of [[Mali]]
+*''[[Yadegar-e Zariran]]'' ([[Middle Persian]])
+*''[[Yama Zatdaw]]'', Burmese version of the Ramayana

--- a/src/epic.rs
+++ b/src/epic.rs
@@ -1,0 +1,61 @@
+/// An Epic object contains all the information about an epic poem that we care
+/// about when we're generating messages.
+#[derive(Debug)]
+pub struct Epic {
+    /// The title of the epic poem
+    pub title: &'static str,
+    /// We store the Wikipedia article that we want to use for attribution. If a
+    /// given poem doesn't have an appropriate Wikipedia article to link to,
+    /// this will contain `None`.
+    pub wiki: Option<&'static str>,
+}
+
+/// A list of epic poems
+pub static EPICS: &[Epic] = &[
+    // 8th to 6th century BC
+    Epic {
+        title: "Epic of Gilgamesh",
+        wiki: Some("Epic of Gilgamesh"),
+    },
+    Epic {
+        title: "Atrahasis",
+        wiki: Some("Atra-Hasis"),
+    },
+    Epic {
+        title: "Enuma Elish ",
+        wiki: Some("Enuma Elish"),
+    },
+    Epic {
+        title: "Legend of Keret",
+        wiki: Some("Legend of Keret"),
+    },
+    Epic {
+        title: "Cycle of Kumarbi",
+        wiki: Some("Kumarbi"),
+    },
+    // 20th to 10th century BC
+    Epic {
+        title: "Iliad",
+        wiki: Some("Iliad"),
+    },
+    Epic {
+        title: "Odyssey",
+        wiki: Some("Odyssey"),
+    },
+    Epic {
+        title: "Works and Days",
+        wiki: Some("Works and Days"),
+    },
+    Epic {
+        title: "Theogony",
+        wiki: Some("Theogony"),
+    },
+    Epic {
+        title: "Shield of Heracles",
+        wiki: Some("Shield of Heracles"),
+    },
+    Epic {
+        title: "Catalogue of Women",
+        wiki: Some("Catalogue of Women"),
+    },
+];

--- a/src/epic.rs
+++ b/src/epic.rs
@@ -7,7 +7,29 @@ pub struct Epic {
     /// We store the Wikipedia article that we want to use for attribution. If a
     /// given poem doesn't have an appropriate Wikipedia article to link to,
     /// this will contain `None`.
-    pub wiki: Option<&'static str>,
+    wiki: Wiki,
+}
+
+impl Epic {
+    /// Returns the URL of the Wikipedia article that we want to use for
+    /// attribution. If a given poem doesn't have an appropriate Wikipedia
+    /// article to link to, this will be `None`.
+    pub fn wiki(&self) -> Option<String> {
+        let name = match self.wiki {
+            Wiki::None => return None,
+            Wiki::Same => self.title,
+            Wiki::Name(name) => name,
+        };
+        let name = name.replace(" ", "_");
+        Some(format!("https://en.wikipedia.org/wiki/{}", name))
+    }
+}
+
+#[derive(Debug, PartialEq)]
+enum Wiki {
+    None,
+    Same,
+    Name(&'static str),
 }
 
 /// A list of epic poems
@@ -15,47 +37,97 @@ pub static EPICS: &[Epic] = &[
     // 8th to 6th century BC
     Epic {
         title: "Epic of Gilgamesh",
-        wiki: Some("Epic of Gilgamesh"),
+        wiki: Wiki::Same,
     },
     Epic {
         title: "Atrahasis",
-        wiki: Some("Atra-Hasis"),
+        wiki: Wiki::Name("Atra-Hasis"),
     },
     Epic {
-        title: "Enuma Elish ",
-        wiki: Some("Enuma Elish"),
+        title: "Enûma Eliš",
+        wiki: Wiki::Same,
     },
     Epic {
         title: "Legend of Keret",
-        wiki: Some("Legend of Keret"),
+        wiki: Wiki::Same,
     },
     Epic {
         title: "Cycle of Kumarbi",
-        wiki: Some("Kumarbi"),
+        wiki: Wiki::Same,
     },
     // 20th to 10th century BC
     Epic {
         title: "Iliad",
-        wiki: Some("Iliad"),
+        wiki: Wiki::Same,
     },
     Epic {
         title: "Odyssey",
-        wiki: Some("Odyssey"),
+        wiki: Wiki::Same,
     },
     Epic {
         title: "Works and Days",
-        wiki: Some("Works and Days"),
+        wiki: Wiki::Same,
     },
     Epic {
         title: "Theogony",
-        wiki: Some("Theogony"),
+        wiki: Wiki::Same,
     },
     Epic {
         title: "Shield of Heracles",
-        wiki: Some("Shield of Heracles"),
+        wiki: Wiki::Same,
     },
     Epic {
         title: "Catalogue of Women",
-        wiki: Some("Catalogue of Women"),
+        wiki: Wiki::Same,
     },
 ];
+
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_wiki_url_same() {
+        assert_eq!(
+            Epic {
+                title: "Odyssey",
+                wiki: Wiki::Same,
+            }.wiki(),
+            Some("https://en.wikipedia.org/wiki/Odyssey".into())
+        );
+    }
+
+    #[test]
+    fn test_wiki_url_different() {
+        assert_eq!(
+            Epic {
+                title: "Atrahasis",
+                wiki: Wiki::Name("Atra-Hasis"),
+            }.wiki(),
+            Some("https://en.wikipedia.org/wiki/Atra-Hasis".into())
+        );
+    }
+
+    #[test]
+    fn test_wiki_url_none() {
+        assert_eq!(
+            Epic {
+                title: "Dona Branca",
+                wiki: Wiki::None,
+            }.wiki(),
+            None
+        );
+    }
+
+    #[test]
+    fn test_wiki_url_spaces() {
+        assert_eq!(
+            Epic {
+                title: "Epic of Gilgamesh",
+                wiki: Wiki::Same,
+            }.wiki(),
+            Some("https://en.wikipedia.org/wiki/Epic_of_Gilgamesh".into())
+        );
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,19 @@
 mod name_gen;
-
-use name_gen::*;
+mod epic;
 
 fn main() {
-    println!("{}", super_mario_epic("Odyssey"))
+    for epic in epic::EPICS {
+        match epic.wiki {
+            Some(wiki) => {
+                let title = name_gen::super_mario_epic(epic.title);
+                println!("{} ({})", title, wiki);
+            }
+            None => {
+                println!(
+                    "{}",
+                    name_gen::super_mario_epic(epic.title),
+                )
+            }
+        }
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,7 @@ mod epic;
 
 fn main() {
     for epic in epic::EPICS {
-        match epic.wiki {
+        match epic.wiki() {
             Some(wiki) => {
                 let title = name_gen::super_mario_epic(epic.title);
                 println!("{} ({})", title, wiki);


### PR DESCRIPTION
This adds the raw text of the Wikipedia article [List of Epic Poems], and also a struct `Epic`.
This starts the list of poems as well.

(We should leave this branch open even after this gets merged so I can finish writing the poems.)

[List of Epic Poems]: https://en.wikipedia.org/wiki/List_of_epic_poems